### PR TITLE
upgrade to tf 1.0

### DIFF
--- a/py/fm_model.py
+++ b/py/fm_model.py
@@ -52,7 +52,7 @@ class FmModelBase:
       local_params = tf.nn.embedding_lookup(self.vocab_blocks, ori_ids)
       self.pred_score, reg_score = fm_ops.fm_scorer(feature_ids, local_params, feature_vals, feature_poses, factor_lambda, bias_lambda)
       if loss_type == 'logistic':
-        self.loss = tf.reduce_sum(weights * tf.nn.sigmoid_cross_entropy_with_logits(self.pred_score, labels))
+        self.loss = tf.reduce_sum(weights * tf.nn.sigmoid_cross_entropy_with_logits(logits=self.pred_score, labels=labels))
       elif loss_type == 'mse':
         self.loss = tf.reduce_sum(weights * tf.square(self.pred_score - labels))
       else:


### PR DESCRIPTION
Before this change:
```
Traceback (most recent call last):
  File "fast_tffm.py", line 101, in <module>
    local_train(train_files, weight_files, validation_files, epoch_num, vocabulary_size, vocabulary_block_num, hash_feature_id, factor_num, init_value_range, loss_type, optimizer, batch_size, factor_lambda, bias_lambda, thread_num, model_file)
  File "D:\os\fast_tffm\py\fm_train.py", line 100, in local_train
    model = LocalFmModel(_queue_size(train_files, validation_files, epoch_num), epoch_num, vocabulary_size, vocabulary_block_num, hash_feature_id,factor_num, init_value_range, loss_type, optimizer, batch_size, factor_lambda, bias_lambda)
  File "D:\os\fast_tffm\py\fm_model.py", line 55, in __init__
    self.loss = tf.reduce_sum(weights * tf.nn.sigmoid_cross_entropy_with_logits(self.pred_score, labels))
  File "C:\Python35\lib\site-packages\tensorflow\python\ops\nn_impl.py", line 147, in sigmoid_cross_entropy_with_logits
    _sentinel, labels, logits)
  File "C:\Python35\lib\site-packages\tensorflow\python\ops\nn_ops.py", line 1535, in _ensure_xent_args
    "named arguments (labels=..., logits=..., ...)" % name)
ValueError: Only call `sigmoid_cross_entropy_with_logits` with named arguments (labels=..., logits=..., ...)
```